### PR TITLE
More icons

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -33,6 +33,10 @@
 	<h2>Default behaviour</h2>
     <star-rating></star-rating>
 
+    <star-rating icon="face"></star-rating>
+   
+    <star-rating icon="heart"></star-rating>
+    
     <h2>Custom number of stars</h2>
     <star-rating stars="10"></star-rating>
     

--- a/demo.html
+++ b/demo.html
@@ -36,6 +36,8 @@
     <star-rating icon="face"></star-rating>
    
     <star-rating icon="heart"></star-rating>
+
+    <star-rating customCharIcon="Ω"></star-rating>
     
     <h2>Custom number of stars</h2>
     <star-rating stars="10"></star-rating>

--- a/star-rating.css
+++ b/star-rating.css
@@ -13,11 +13,15 @@
   width: 1em;
   font-size: 1.5em;
   cursor: pointer;
+  opacity: 0.4;
 }
-.star-rating-wrapper > span:hover:before,
-.star-rating-wrapper > span:hover ~ span:before,
-.star-rating-wrapper > span.active:before,
-.star-rating-wrapper > span.active ~ span:before {
-   content: "\2605";
-   position: absolute;
+
+.star-rating-wrapper > span:hover,
+.star-rating-wrapper > span:hover ~ span {
+  opacity: 0.8;
+}
+.star-rating-wrapper > span.active,
+.star-rating-wrapper > span.active ~ span {
+   opacity: 1;
+
 }

--- a/star-rating.html
+++ b/star-rating.html
@@ -85,7 +85,7 @@ A Polymer element for star ratings.
       },
       setRate: function(e,d,t) {
         this.rate = parseInt(t.dataset.item, 10 );
-      },
+      }
     });
 </script>
 </polymer-element>

--- a/star-rating.html
+++ b/star-rating.html
@@ -33,7 +33,17 @@ A Polymer element for star ratings.
 
   <div class="star-rating-wrapper">
     <template repeat="{{n in currentStars}}">
-      <span class="{{n == rate ? 'active' : ''}}" on-click="{{setRate}}" data-item="{{n}}">&#9734;</span>
+      <span class="{{n == rate ? 'active' : ''}}" on-click="{{setRate}}" data-item="{{n}}">
+	<template if="icon==='star'">
+		&#9734;
+	</template>
+	<template if="icon==='heart'">
+		&#9825;
+	</template>
+	<template if="icon==='face'">
+		&#9786;
+	</template>
+      </span>
     </template>
   </div>
 
@@ -46,6 +56,11 @@ A Polymer element for star ratings.
        * @type {Number}
        */
        stars: 5,
+      /**
+       * icon: the icon to use. Options: 'star' (defualt), 'heart', 'face'
+       * @type {String}
+       */
+       icon: 'star',
       /**
        * rate: numbers of star selected
        * @type {Number}

--- a/star-rating.html
+++ b/star-rating.html
@@ -25,7 +25,7 @@ A Polymer element for star ratings.
 @status alpha
 @url cmartinezv.github.io/webcomponents
 -->
-<polymer-element name="star-rating" attributes="stars rate">
+<polymer-element name="star-rating" attributes="stars rate icon customCharIcon">
 
 <template>
 
@@ -34,15 +34,20 @@ A Polymer element for star ratings.
   <div class="star-rating-wrapper">
     <template repeat="{{n in currentStars}}">
       <span class="{{n == rate ? 'active' : ''}}" on-click="{{setRate}}" data-item="{{n}}">
-	<template if="icon==='star'">
-		&#9734;
-	</template>
-	<template if="icon==='heart'">
-		&#9825;
-	</template>
-	<template if="icon==='face'">
-		&#9786;
-	</template>
+        <template if="{{customCharIcon}}">
+          {{customCharIcon}}
+        </template>
+        <template if="{{!customCharIcon}}">
+        	<template if="{{icon=='star'}}">
+        		&#9734;
+        	</template>
+        	<template if="{{icon=='heart'}}">
+        		&#9825;
+        	</template>
+        	<template if="{{icon=='face'}}">
+        		&#9786;
+        	</template>
+        </template>
       </span>
     </template>
   </div>
@@ -62,6 +67,11 @@ A Polymer element for star ratings.
        */
        icon: 'star',
       /**
+       * customCharIcon: custom Unicode character to be used to create icons (e.g. 'Ω'). It supresses icon attribute //TODO: works when set in JS doesn't work when it is * set in html tag (see demo.html). Neitehr works unicode codes.
+       * @type {String}
+       */
+       customCharIcon: null,
+      /**
        * rate: numbers of star selected
        * @type {Number}
        */
@@ -73,10 +83,9 @@ A Polymer element for star ratings.
           this.currentStars.push(i+1);
         };
       },
-
       setRate: function(e,d,t) {
         this.rate = parseInt(t.dataset.item, 10 );
-      }
+      },
     });
 </script>
 </polymer-element>


### PR DESCRIPTION
Thanks for the component. Here are some changes to make component accept any character as icon. Unfortunately custom characters doesn't work when it is not ASCII (see demo.html). Neither does Unicode chars like &#9786; or \u263A work, when used as expression in double mustache (line 38 of star-rating.html). Maybe needs a [filter](https://github.com/addyosmani/polymer-filters) for escaping?!. 
